### PR TITLE
feat: add per-client stream selection

### DIFF
--- a/web/handlers/clientid.go
+++ b/web/handlers/clientid.go
@@ -1,0 +1,32 @@
+package web
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+)
+
+const clientIDCookieName = "client-id"
+
+// getClientID returns a stable identifier for the client using a cookie.
+// If the cookie is missing, it generates a new random identifier and sets it.
+func getClientID(w http.ResponseWriter, r *http.Request) string {
+	cookie, err := r.Cookie(clientIDCookieName)
+	if err == nil && cookie.Value != "" {
+		return cookie.Value
+	}
+
+	var randomBytes [16]byte
+	if _, err := rand.Read(randomBytes[:]); err != nil {
+		identifier := r.RemoteAddr
+		http.SetCookie(w, &http.Cookie{Name: clientIDCookieName, Value: identifier, Path: "/"})
+		return identifier
+	}
+	identifier := hex.EncodeToString(randomBytes[:])
+	http.SetCookie(w, &http.Cookie{
+		Name:  clientIDCookieName,
+		Value: identifier,
+		Path:  "/",
+	})
+	return identifier
+}

--- a/web/handlers/clientid.go
+++ b/web/handlers/clientid.go
@@ -3,30 +3,13 @@ package web
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"net/http"
 )
 
-const clientIDCookieName = "client-id"
-
-// getClientID returns a stable identifier for the client using a cookie.
-// If the cookie is missing, it generates a new random identifier and sets it.
-func getClientID(w http.ResponseWriter, r *http.Request) string {
-	cookie, err := r.Cookie(clientIDCookieName)
-	if err == nil && cookie.Value != "" {
-		return cookie.Value
-	}
-
+// generateClientID creates a random identifier used to distinguish browser connections.
+func generateClientID() string {
 	var randomBytes [16]byte
 	if _, err := rand.Read(randomBytes[:]); err != nil {
-		identifier := r.RemoteAddr
-		http.SetCookie(w, &http.Cookie{Name: clientIDCookieName, Value: identifier, Path: "/"})
-		return identifier
+		return ""
 	}
-	identifier := hex.EncodeToString(randomBytes[:])
-	http.SetCookie(w, &http.Cookie{
-		Name:  clientIDCookieName,
-		Value: identifier,
-		Path:  "/",
-	})
-	return identifier
+	return hex.EncodeToString(randomBytes[:])
 }

--- a/web/handlers/dashboard.go
+++ b/web/handlers/dashboard.go
@@ -33,6 +33,14 @@ func NewDashboard() (dashboard *Dashboard, err error) {
 	templates := template.New("").Funcs(template.FuncMap{
 		"sub":        func(a, b float64) float64 { return a - b },
 		"keyToTitle": func(s string) string { return strings.Replace(s, "-", " ", -1) },
+		"dict": func(values ...interface{}) map[string]interface{} {
+			dictionary := make(map[string]interface{}, len(values)/2)
+			for i := 0; i+1 < len(values); i += 2 {
+				key, _ := values[i].(string)
+				dictionary[key] = values[i+1]
+			}
+			return dictionary
+		},
 	})
 	dashboard.templates, err = templates.ParseGlob("web/templates/dashboard/*.gohtml")
 	return dashboard, err
@@ -109,7 +117,7 @@ func (d *Dashboard) CycleStreamHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientIdentifier := getClientID(w, r)
+	clientIdentifier := r.URL.Query().Get("client")
 
 	// Find the stream by key
 	c := store.DashboardCharts[sig.Chart.Key]

--- a/web/handlers/dashboard.go
+++ b/web/handlers/dashboard.go
@@ -109,7 +109,7 @@ func (d *Dashboard) CycleStreamHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientID := r.RemoteAddr
+	clientIdentifier := getClientID(w, r)
 
 	// Find the stream by key
 	c := store.DashboardCharts[sig.Chart.Key]
@@ -118,12 +118,12 @@ func (d *Dashboard) CycleStreamHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	idx := d.activeStreamIndex(clientID, c)
+	idx := d.activeStreamIndex(clientIdentifier, c)
 	idx = (idx + 1) % len(c.Streams())
-	d.setActiveStreamIndex(clientID, c, idx)
+	d.setActiveStreamIndex(clientIdentifier, c, idx)
 	activeStreamKey := c.Streams()[idx].Key()
 
-	chartCopy := d.chartCopyForClient(clientID, c)
+	chartCopy := d.chartCopyForClient(clientIdentifier, c)
 
 	var buf strings.Builder
 	err := d.templates.ExecuteTemplate(&buf, "activeStream.title", chartCopy)

--- a/web/handlers/renderer.go
+++ b/web/handlers/renderer.go
@@ -11,5 +11,5 @@ type Renderer interface {
 	Templates() *template.Template
 	Handlers() map[string]func(r http.ResponseWriter, w *http.Request)
 	Data() map[string]interface{}
-	OnTick(sse *ds.ServerSentEventGenerator, currentTimeMs int) error
+	OnTick(sse *ds.ServerSentEventGenerator, currentTimeMs int, clientID string) error
 }

--- a/web/handlers/server.go
+++ b/web/handlers/server.go
@@ -51,8 +51,11 @@ func (s *Server) Start(addr string) error {
 
 // IndexHandler is the main entrypoint for the UI
 func (s *Server) IndexHandler(w http.ResponseWriter, r *http.Request) {
-	getClientID(w, r)
-	err := s.renderer.Templates().ExecuteTemplate(w, "index", s.renderer.Data())
+	clientIdentifier := generateClientID()
+	data := s.renderer.Data()
+	data["clientID"] = clientIdentifier
+
+	err := s.renderer.Templates().ExecuteTemplate(w, "index", data)
 	if err != nil {
 		log.Printf("couldn't execute template for index %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -60,7 +63,10 @@ func (s *Server) IndexHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) TickHandler(w http.ResponseWriter, r *http.Request) {
-	clientIdentifier := getClientID(w, r)
+	clientIdentifier := r.URL.Query().Get("client")
+	if clientIdentifier == "" {
+		clientIdentifier = generateClientID()
+	}
 	sse := ds.NewSSE(w, r)
 	c := &client{id: clientIdentifier, sse: sse}
 

--- a/web/handlers/server.go
+++ b/web/handlers/server.go
@@ -50,7 +50,8 @@ func (s *Server) Start(addr string) error {
 }
 
 // IndexHandler is the main entrypoint for the UI
-func (s *Server) IndexHandler(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) IndexHandler(w http.ResponseWriter, r *http.Request) {
+	getClientID(w, r)
 	err := s.renderer.Templates().ExecuteTemplate(w, "index", s.renderer.Data())
 	if err != nil {
 		log.Printf("couldn't execute template for index %s", err)
@@ -59,8 +60,9 @@ func (s *Server) IndexHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) TickHandler(w http.ResponseWriter, r *http.Request) {
+	clientIdentifier := getClientID(w, r)
 	sse := ds.NewSSE(w, r)
-	c := &client{id: r.RemoteAddr, sse: sse}
+	c := &client{id: clientIdentifier, sse: sse}
 
 	s.mu.Lock()
 	s.clients[c] = struct{}{}

--- a/web/templates/dashboard/chart.gohtml
+++ b/web/templates/dashboard/chart.gohtml
@@ -1,18 +1,18 @@
 {{ define "chart" }}
 
     <div class="card"
-         id="{{ .Key }}-card"
+         id="{{ .Chart.Key }}-card"
          data-on-click__throttle.200ms="
-        $chart = { key: '{{ .Key }}' };
-        @post('/toggle-active-stream', { filterSignals: { include: /^chart\./ } })"
+        $chart = { key: '{{ .Chart.Key }}' };
+        @post('/toggle-active-stream?client={{ .ClientID }}', { filterSignals: { include: /^chart\./ } })"
     >
-        {{ template "activeStream.title" . }}
+        {{ template "activeStream.title" .Chart }}
         <div class="value">
-            {{ template "activeStream.value" . }}
-            {{ template "activeStream.unit" . }}
+            {{ template "activeStream.value" .Chart }}
+            {{ template "activeStream.unit" .Chart }}
         </div>
         <div class="chart">
-            {{ range $s := .Streams }}
+            {{ range $s := .Chart.Streams }}
                 {{ template "sparkline" $s }}
             {{ end }}
         </div>

--- a/web/templates/dashboard/index.gohtml
+++ b/web/templates/dashboard/index.gohtml
@@ -10,10 +10,10 @@
     </head>
     <body>
     <script src="/static/dashboard/js/sparkline.js"></script>
-    <div data-on-load="@get('/tick')"></div>
+    <div data-on-load="@get('/tick?client={{ .clientID }}')"></div>
 
     {{ range .charts }}
-        {{ template "chart" . }}
+        {{ template "chart" dict "Chart" . "ClientID" $.clientID }}
     {{ end }}
     </body>
     </html>


### PR DESCRIPTION
## Summary
- track active streams per client and cycle without affecting other users
- centralize ticking to broadcast updates to all clients and clear svg points once per tick

------
https://chatgpt.com/codex/tasks/task_e_68b2060594548333aa6ba3e8654d7e05